### PR TITLE
Remove AddThis widget

### DIFF
--- a/web/app/themes/layobservers/footer.php
+++ b/web/app/themes/layobservers/footer.php
@@ -29,9 +29,5 @@ var google_remarketing_only = false;
 
 <?php wp_footer(); ?>
 
-<!-- Go to www.addthis.com/dashboard to customize your tools -->
-<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-562f51153023de54" async="async"></script>
-
 </body>
 </html>
-


### PR DESCRIPTION
The AddThis widget was bringing in lots of cookies, whihc we would have had to made toggleable and added into a new functionality section of the cookie banner. Looking at it, it looks a bit phishy, and we've already made the decision to remove it off of other sites previously.